### PR TITLE
Separate `keepKeys` and `allowNullishKeys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Recursively reduce an object to match a given map.
  - Provide options:
    -  keepKeys: Retain mismatched keys as null opposed to deleting them 
    -  throwErrorOnAlien: Throw error on alien found
+   -  allowNullishKeys: Preserve null or undefined keys in the output
 
 ## Breaking changes 1 -> 2
 In version 1 a bug was discovered that permitted alien keys of null value into the output. This has now been resolved however may cause any tools using this helper tool to break, hence the major version bump.

--- a/__tests__/allowNullishKeys_test.js
+++ b/__tests__/allowNullishKeys_test.js
@@ -1,4 +1,4 @@
-const reducer = require('../src/reducer')
+const reducer = require('../src/reducer');
 
 describe('Test passing null keys through', () => {
   const map = {
@@ -7,145 +7,174 @@ describe('Test passing null keys through', () => {
     type: String,
     health: Number,
     wear: Number,
-  }
+  };
 
-  const baseInput = {
-    id: 10,
-    date: '1970-01-01',
-  }
-
-  const keepKeys = {
+  const mapWithNullValues = {
     id: null,
     date: null,
     type: null,
     health: null,
     wear: null,
-    ...baseInput,
-  }
+  };
 
-  const defaultOptions = { throwOnAlien: false, allowNullish: true, keepKeys: false, allowNullishKeys: false }
+  const defaultOptions = { throwOnAlien: false, allowNullish: true, keepKeys: false, allowNullishKeys: false };
 
   it('does not alter default behaviour', () => {
     const testInput = {
       id: 10,
       date: '1970-01-01',
       type: 'test',
-    }
+    };
 
-    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput)
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({ ...keepKeys, ...testInput })
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
-      ...keepKeys,
+    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput);
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
+      id: 10,
+      date: '1970-01-01',
       type: 'test',
-    })
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
-  })
+      health: null,
+      wear: null,
+    });
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
+      id: 10,
+      date: '1970-01-01',
+      type: 'test',
+      health: null,
+      wear: null,
+    });
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
+  });
 
   it('will pass null keys through', () => {
     const testInput = {
       id: 10,
       date: '1970-01-01',
       type: null,
-    }
+    };
 
-    expect(reducer(testInput, map, defaultOptions)).toEqual(baseInput)
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({ ...keepKeys, ...testInput })
+    expect(reducer(testInput, map, defaultOptions)).toEqual({
+      id: 10,
+      date: '1970-01-01',
+    });
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
+      id: 10,
+      date: '1970-01-01',
+      type: null,
+      health: null,
+      wear: null,
+    });
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
-      ...keepKeys,
-    })
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
-  })
+      id: 10,
+      date: '1970-01-01',
+      type: null,
+      health: null,
+      wear: null,
+    });
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
+  });
 
   it('will ignore undefined', () => {
     const testInput = {
       id: 10,
       date: '1970-01-01',
       type: undefined,
-    }
+    };
 
-    expect(reducer(testInput, map, defaultOptions)).toEqual(baseInput)
+    expect(reducer(testInput, map, defaultOptions)).toEqual({
+      id: 10,
+      date: '1970-01-01',
+    });
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
-      ...keepKeys,
       id: 10,
       date: '1970-01-01',
-    })
+      type: null,
+      health: null,
+      wear: null,
+    });
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
-      ...keepKeys,
       id: 10,
       date: '1970-01-01',
-    })
+      type: null,
+      health: null,
+      wear: null,
+    });
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
-    })
-  })
+    });
+  });
 
   it('will not alter behaviour for keys not defined in map', () => {
     const testInput = {
       id: 10,
       date: '1970-01-01',
       test: 10,
-    }
+    };
 
-    expect(reducer(testInput, map, defaultOptions)).toEqual(baseInput)
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({ ...keepKeys })
+    expect(reducer(testInput, map, defaultOptions)).toEqual({
+      id: 10,
+      date: '1970-01-01',
+    });
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
+      id: 10,
+      date: '1970-01-01',
+      type: null,
+      health: null,
+      wear: null,
+    });
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
-      ...keepKeys,
-    })
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(baseInput)
-  })
+      id: 10,
+      date: '1970-01-01',
+      type: null,
+      health: null,
+      wear: null,
+    });
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual({
+      id: 10,
+      date: '1970-01-01',
+    });
+  });
 
   it('handles null', () => {
-    const testInput = null
+    const testInput = null;
 
-    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput)
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual(testInput)
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual(testInput)
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
-  })
+    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput);
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual(testInput);
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual(testInput);
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
+  });
 
   it('handles empty object', () => {
-    const testInput = {}
+    const testInput = {};
 
-    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput)
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
-      id: null,
-      date: null,
-      type: null,
-      health: null,
-      wear: null,
-    })
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
-      id: null,
-      date: null,
-      type: null,
-      health: null,
-      wear: null,
-    })
-    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
-  })
+    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput);
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual(mapWithNullValues);
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual(
+      mapWithNullValues
+    );
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
+  });
 
-  it('has no effect on throw on alien', async () => {
-    const testInput = {}
+  it('has no effect on throw on alien', () => {
+    const testInput = {};
 
     try {
-      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true })
-      expect(false).toBe(true)
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true });
+      expect(false).toBe(true);
     } catch (e) {}
 
     try {
-      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: true })
-      expect(false).toBe(true)
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: true });
+      expect(false).toBe(true);
     } catch (e) {}
 
     try {
-      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: true, allowNullishKeys: true })
-      expect(false).toBe(true)
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: true, allowNullishKeys: true });
+      expect(false).toBe(true);
     } catch (e) {}
 
     try {
-      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: false, allowNullishKeys: true })
-      expect(false).toBe(true)
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: false, allowNullishKeys: true });
+      expect(false).toBe(true);
     } catch (e) {}
-  })
-})
+  });
+});

--- a/__tests__/allowNullishKeys_test.js
+++ b/__tests__/allowNullishKeys_test.js
@@ -1,0 +1,151 @@
+const reducer = require('../src/reducer')
+
+describe('Test passing null keys through', () => {
+  const map = {
+    id: Number,
+    date: String,
+    type: String,
+    health: Number,
+    wear: Number,
+  }
+
+  const baseInput = {
+    id: 10,
+    date: '1970-01-01',
+  }
+
+  const keepKeys = {
+    id: null,
+    date: null,
+    type: null,
+    health: null,
+    wear: null,
+    ...baseInput,
+  }
+
+  const defaultOptions = { throwOnAlien: false, allowNullish: true, keepKeys: false, allowNullishKeys: false }
+
+  it('does not alter default behaviour', () => {
+    const testInput = {
+      id: 10,
+      date: '1970-01-01',
+      type: 'test',
+    }
+
+    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({ ...keepKeys, ...testInput })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
+      ...keepKeys,
+      type: 'test',
+    })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
+  })
+
+  it('will pass null keys through', () => {
+    const testInput = {
+      id: 10,
+      date: '1970-01-01',
+      type: null,
+    }
+
+    expect(reducer(testInput, map, defaultOptions)).toEqual(baseInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({ ...keepKeys, ...testInput })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
+      ...keepKeys,
+    })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
+  })
+
+  it('will ignore undefined', () => {
+    const testInput = {
+      id: 10,
+      date: '1970-01-01',
+      type: undefined,
+    }
+
+    expect(reducer(testInput, map, defaultOptions)).toEqual(baseInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
+      ...keepKeys,
+      id: 10,
+      date: '1970-01-01',
+    })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
+      ...keepKeys,
+      id: 10,
+      date: '1970-01-01',
+    })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual({
+      id: 10,
+      date: '1970-01-01',
+    })
+  })
+
+  it('will not alter behaviour for keys not defined in map', () => {
+    const testInput = {
+      id: 10,
+      date: '1970-01-01',
+      test: 10,
+    }
+
+    expect(reducer(testInput, map, defaultOptions)).toEqual(baseInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({ ...keepKeys })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
+      ...keepKeys,
+    })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(baseInput)
+  })
+
+  it('handles null', () => {
+    const testInput = null
+
+    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual(testInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual(testInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
+  })
+
+  it('handles empty object', () => {
+    const testInput = {}
+
+    expect(reducer(testInput, map, defaultOptions)).toEqual(testInput)
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
+      id: null,
+      date: null,
+      type: null,
+      health: null,
+      wear: null,
+    })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
+      id: null,
+      date: null,
+      type: null,
+      health: null,
+      wear: null,
+    })
+    expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput)
+  })
+
+  it('has no effect on throw on alien', async () => {
+    const testInput = {}
+
+    try {
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true })
+      expect(false).toBe(true)
+    } catch (e) {}
+
+    try {
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: true })
+      expect(false).toBe(true)
+    } catch (e) {}
+
+    try {
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: true, allowNullishKeys: true })
+      expect(false).toBe(true)
+    } catch (e) {}
+
+    try {
+      reducer(testInput, map, { ...defaultOptions, throwOnAlien: true, keepKeys: false, allowNullishKeys: true })
+      expect(false).toBe(true)
+    } catch (e) {}
+  })
+})

--- a/__tests__/allowNullishKeys_test.js
+++ b/__tests__/allowNullishKeys_test.js
@@ -26,7 +26,9 @@ describe('Test passing null keys through', () => {
       type: 'test',
     };
 
+
     expect(reducer(testInput, map, defaultOptions)).toEqual(testInput);
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -34,6 +36,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -41,6 +44,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
   });
 
@@ -51,10 +55,12 @@ describe('Test passing null keys through', () => {
       type: null,
     };
 
+
     expect(reducer(testInput, map, defaultOptions)).toEqual({
       id: 10,
       date: '1970-01-01',
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -62,6 +68,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -69,6 +76,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
   });
 
@@ -79,10 +87,12 @@ describe('Test passing null keys through', () => {
       type: undefined,
     };
 
+
     expect(reducer(testInput, map, defaultOptions)).toEqual({
       id: 10,
       date: '1970-01-01',
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -90,6 +100,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -97,6 +108,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -110,10 +122,12 @@ describe('Test passing null keys through', () => {
       test: 10,
     };
 
+
     expect(reducer(testInput, map, defaultOptions)).toEqual({
       id: 10,
       date: '1970-01-01',
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -121,6 +135,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -128,6 +143,7 @@ describe('Test passing null keys through', () => {
       health: null,
       wear: null,
     });
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual({
       id: 10,
       date: '1970-01-01',
@@ -137,20 +153,28 @@ describe('Test passing null keys through', () => {
   it('handles null', () => {
     const testInput = null;
 
+
     expect(reducer(testInput, map, defaultOptions)).toEqual(testInput);
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual(testInput);
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual(testInput);
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
   });
 
   it('handles empty object', () => {
     const testInput = {};
 
+
     expect(reducer(testInput, map, defaultOptions)).toEqual(testInput);
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true })).toEqual(mapWithNullValues);
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: true, allowNullishKeys: true })).toEqual(
       mapWithNullValues
     );
+
     expect(reducer(testInput, map, { ...defaultOptions, keepKeys: false, allowNullishKeys: true })).toEqual(testInput);
   });
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,5 +15,11 @@ interface Options {
    * If true, will pass null or undefined through
    */
   allowNullish?: boolean
+
+  /**
+   * If true, will pass null or undefined keys through
+   */
+  allowNullishKeys?: boolean
 }
+
 export default function(input: object, map: object, options?: Options): object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "object-reduce-by-map",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "object-reduce-by-map",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Recursively reduce an object to match a given map.",
   "main": "src/reducer.js",
   "scripts": {


### PR DESCRIPTION
closes #11 

`keepKeys` will add keys which are in the map but not the output (default behaviour)
`allowNullishKeys` will pass null or undefined keys through without trimming them